### PR TITLE
fix: only compile integration test support if the feature is enabled

### DIFF
--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(testing_utils)]
+
 mod bitcoin_simulator;
 
 use crate::rpc::FeePallet;


### PR DESCRIPTION
.. So that we can skip compilation of a LOT of dependencies if we just want to build the clients without building integration tests. The feature selection by cargo is going wrong somehow, so to actually skip compiling the dependencies, make this temporary change:

```
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 default = []
-testing-utils = ["substrate-subxt-client", "tempdir", "btc-parachain", "btc-parachain-service", "bitcoin", "rand"]
+testing-utils = []
```
