### PR TITLE
Chore: gitlab-ci.yml for external pull requetss

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,11 @@ image: "registry.gitlab.com/interlay/containers/rust-base:nightly-2021-03-15"
         - master
         - dev
 
+workflow:
+    rules:
+        - if: $CI_COMMIT_TAG
+        - if: $CI_COMMIT_BRANCH
+
 stages:
     - test
     - build
@@ -50,8 +55,6 @@ test-clients:
         key: cargo
         paths:
             - .cargo
-    only:
-        - external_pull_requests
 
 build-clients:
     stage: build


### PR DESCRIPTION
Trigger gitlab CI builds for pull requests from external repositories.
Ref.: https://gitlab.com/gitlab-org/gitlab/-/issues/5667