### PR TITLE
Chore: Use CI_COMMIT_REF_NAME for tagging docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,8 +103,8 @@ build-docker-images:
                 --build-arg PROFILE="x86_64-unknown-linux-gnu/release" \
                 --context ${CI_PROJECT_DIR} \
                 --dockerfile ${CI_PROJECT_DIR}/.deploy/Dockerfile \
-                --destination ${CI_REGISTRY_IMAGE}/${IMAGE}:${CI_COMMIT_SHORT_SHA} \
-                --destination ${CI_REGISTRY_IMAGE}/${IMAGE}:${CI_COMMIT_REF_SLUG}
+                --destination ${CI_REGISTRY_IMAGE}/${IMAGE}:${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}-$(date +%s) \
+                --destination ${CI_REGISTRY_IMAGE}/${IMAGE}:${CI_COMMIT_REF_NAME}
     <<: *only_refs
 
 release-github:


### PR DESCRIPTION
Replace CI_COMMIT_REF_SLUG  with CI_COMMIT_REF_NAME 

From gitlab docs:
<!--StartFragment-->
Variable | GitLab | Runner | Description
-- | -- | -- | --
CI_COMMIT_REF_NAME | 9.0 | all | The branch or tag name for which project is built.
CI_COMMIT_REF_SLUG | 9.0 | all | CI_COMMIT_REF_NAME&nbsp;in lowercase, shortened to 63 bytes, and with everything except&nbsp;0-9&nbsp;and&nbsp;a-z&nbsp;replaced with&nbsp;-. No leading / trailing&nbsp;-. Use in URLs, host names and domain names.

<!--EndFragment-->

